### PR TITLE
Document the configured git branch must already exist

### DIFF
--- a/app.json
+++ b/app.json
@@ -40,7 +40,7 @@
       "value": "https://github.com/Organization/Repo"
     },
     "WIKI_GIT_BRANCH": {
-      "description": "Branch of the remote git repository to use",
+      "description": "Branch of the remote git repository to use. This branch must already exist.",
       "value": "master"
     },
     "WIKI_GIT_USERNAME": {


### PR DESCRIPTION
Syncing to a branch that does not yet exist will not create it.